### PR TITLE
updated exceptions and response classes for proper formatting and use…

### DIFF
--- a/api/src/main/kotlin/com/thomasdriscoll/template/lib/dao/TemplateRepo.kt
+++ b/api/src/main/kotlin/com/thomasdriscoll/template/lib/dao/TemplateRepo.kt
@@ -1,4 +1,7 @@
 package com.thomasdriscoll.template.lib.dao
 
+import org.springframework.stereotype.Repository
+
+@Repository
 class TemplateRepo {
 }

--- a/api/src/main/kotlin/com/thomasdriscoll/template/lib/exceptions/DriscollException.kt
+++ b/api/src/main/kotlin/com/thomasdriscoll/template/lib/exceptions/DriscollException.kt
@@ -1,8 +1,9 @@
 package com.thomasdriscoll.template.lib.exceptions
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.springframework.http.HttpStatus
 
 class DriscollException(
-        val status: HttpStatus,
-        message: String
+        @JsonProperty("status") val status: HttpStatus,
+        @JsonProperty("message") message: String
 ) : Exception(message)

--- a/api/src/main/kotlin/com/thomasdriscoll/template/lib/exceptions/TemplateException.kt
+++ b/api/src/main/kotlin/com/thomasdriscoll/template/lib/exceptions/TemplateException.kt
@@ -4,4 +4,5 @@ import org.springframework.http.HttpStatus
 
 enum class ExceptionResponses(val status: HttpStatus, val message: String){
     TESTING_EXCEPTIONS(HttpStatus.BAD_REQUEST, "You done goofed")
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ subprojects{
         testImplementation("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
         }
+        implementation("org.hibernate.validator:hibernate-validator")
         implementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     }
 }
@@ -51,6 +52,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
+    implementation("org.hibernate.validator:hibernate-validator")
+    implementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     implementation("org.springdoc:springdoc-openapi-ui:1.4.8")
     implementation(project(":api"))
 }

--- a/src/main/kotlin/com/thomasdriscoll/template/service/TemplateService.kt
+++ b/src/main/kotlin/com/thomasdriscoll/template/service/TemplateService.kt
@@ -1,14 +1,16 @@
 package com.thomasdriscoll.template.service
 
+import com.thomasdriscoll.template.lib.dao.TemplateRepo
 import com.thomasdriscoll.template.lib.exceptions.DriscollException
 import com.thomasdriscoll.template.lib.exceptions.ExceptionResponses
 import org.springframework.stereotype.Service
 
 @Service
-class TemplateService {
+class TemplateService(val templateRepo: TemplateRepo) {
 
-    fun dummyFunction(name: String) : String{
-        if(name == "Brian"){
+    @Throws(DriscollException::class)
+    fun dummyFunction(name: String) : String {
+        if(name == "Thummus"){
             throw DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,ExceptionResponses.TESTING_EXCEPTIONS.message)
         }
         return "My name is $name"

--- a/src/test/kotlin/com/thomasdriscoll/template/controller/TemplateControllerTest.kt
+++ b/src/test/kotlin/com/thomasdriscoll/template/controller/TemplateControllerTest.kt
@@ -1,35 +1,101 @@
 package com.thomasdriscoll.template.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.*
-import com.thomasdriscoll.template.controller.TemplateController
 import com.thomasdriscoll.template.lib.exceptions.DriscollException
 import com.thomasdriscoll.template.lib.exceptions.ExceptionResponses
+import com.thomasdriscoll.template.lib.responses.DriscollResponse
 import com.thomasdriscoll.template.service.TemplateService
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup
+
 
 internal class TemplateControllerTest {
     private lateinit var templateService: TemplateService
     private lateinit var templateController: TemplateController
     private lateinit var mockMvc: MockMvc
 
-
     @BeforeEach
     fun setup(){
         templateService = mock()
         templateController = TemplateController(templateService)
-        mockMvc = standaloneSetup(templateController)
-                    .build()
-
+        mockMvc = standaloneSetup(templateController).build()
     }
 
-    private val NAME = "thomas"
-    private val BNAME = "Brian"
-    private val RESPONSE = "thomas"
-    private val ERR = DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,ExceptionResponses.TESTING_EXCEPTIONS.message)
+    @Nested
+    @DisplayName("Dummy Function Controller Tests")
+    inner class DummyFunctionControllerTests{
+        private val name :String = "Brian"
+        private val badName :String = "Thummus"
+        private val nameResponse = "My name is Brian"
+
+        @Test
+        fun givenName_whenGetName_thenReturnResponseEntity(){
+            // Declare expected response and other variables used only in this test
+            // Note: ObjectMapper here is mapping Java objects to JSON objects for you
+            val expected:String  = ObjectMapper().writeValueAsString(DriscollResponse(HttpStatus.OK.value(),nameResponse))
+
+            //Mock what needs to be mocked
+            whenever(templateService.dummyFunction(name)).thenReturn(nameResponse)
+
+            val result: MvcResult = mockMvc.perform(get("/$name")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk)
+                .andReturn()
+
+            //Assert if test worked
+            val actual:String = result.response.contentAsString
+            assertEquals(expected,actual)
+        }
+        @Test
+        fun givenInvalidName_whenGetName_thenReturnException(){
+            //variables local to test
+            val exception = DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,
+                                                                 ExceptionResponses.TESTING_EXCEPTIONS.message)
+            val expected: String = ObjectMapper().writeValueAsString(DriscollResponse(exception.status.value(), exception.message))
+
+            //Mock what needs to be mocked
+            whenever(templateService.dummyFunction(badName)).thenThrow(exception) // <- BAD BAD LINE
+            //Do test
+            val result: MvcResult = mockMvc.perform(get("/$badName")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest)
+                .andReturn()
+
+            //Assert if test worked
+            val actual: String = result.response.contentAsString
+            assertEquals(expected, actual)
+        }
+    }
+
+//    private lateinit var templateService: TemplateService
+//    private lateinit var templateController: TemplateController
+//    private lateinit var mockMvc: MockMvc
+//
+//
+//    @BeforeEach
+//    fun setup(){
+//        templateService = mock()
+//        templateController = TemplateController(templateService)
+//        mockMvc = standaloneSetup(templateController)
+//                    .build()
+//
+//    }
+//
+//    private val NAME = "thomas"
+//    private val BNAME = "Brian"
+//    private val RESPONSE = "thomas"
+//    private val ERR = DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,ExceptionResponses.TESTING_EXCEPTIONS.message)
 
 //    @Nested
 //    inner class SanityCheckTests{

--- a/src/test/kotlin/com/thomasdriscoll/template/service/TemplateServiceTest.kt
+++ b/src/test/kotlin/com/thomasdriscoll/template/service/TemplateServiceTest.kt
@@ -1,4 +1,46 @@
 package com.thomasdriscoll.template.service
 
-class TemplateServiceTest {
+import com.nhaarman.mockitokotlin2.mock
+import com.thomasdriscoll.template.lib.dao.TemplateRepo
+import com.thomasdriscoll.template.lib.exceptions.DriscollException
+import com.thomasdriscoll.template.lib.exceptions.ExceptionResponses
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+
+internal class TemplateServiceTest {
+
+    //Complete dummy variable but just wanted to highlight that
+    // you'd probably have one of these in your service tests
+    private lateinit var templateRepo: TemplateRepo
+    private lateinit var templateService: TemplateService
+    @BeforeEach
+    fun setup(){
+        templateRepo = mock()
+        templateService = TemplateService(templateRepo)
+    }
+
+    @Nested
+    @DisplayName("Dummy function service tests")
+    inner class DummyFunctionServiceTests(){
+        private val name : String = "Thomas"
+        private val badName : String = "Thummus"
+        private val nameResponse : String = "My name is Thomas"
+
+        @Test
+        fun whenValidName_returnNameWithMessage() {
+            val actual : String = templateService.dummyFunction(name)
+            assertEquals(nameResponse, actual)
+        }
+
+        @Test
+        fun whenInvalidName_throwException() {
+            val excepted : DriscollException = DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,
+                                                                 ExceptionResponses.TESTING_EXCEPTIONS.message)
+            val actual : DriscollException = assertThrows {templateService.dummyFunction(badName)}
+            //val actual : DriscollException = Assertions.assertThrows(DriscollException::class.java) {templateService.dummyFunction(badName)}
+            //Is this better?
+            assertEquals(excepted.status,actual.status)
+            assertEquals(excepted.message,actual.message)
+        }
+    }
 }

--- a/src/test/kotlin/com/thomasdriscoll/template/service/TemplateServiceTest.kt
+++ b/src/test/kotlin/com/thomasdriscoll/template/service/TemplateServiceTest.kt
@@ -36,9 +36,8 @@ internal class TemplateServiceTest {
         fun whenInvalidName_throwException() {
             val excepted : DriscollException = DriscollException(ExceptionResponses.TESTING_EXCEPTIONS.status,
                                                                  ExceptionResponses.TESTING_EXCEPTIONS.message)
-            val actual : DriscollException = assertThrows {templateService.dummyFunction(badName)}
-            //val actual : DriscollException = Assertions.assertThrows(DriscollException::class.java) {templateService.dummyFunction(badName)}
-            //Is this better?
+
+            val actual : DriscollException = Assertions.assertThrows(DriscollException::class.java) {templateService.dummyFunction(badName)}
             assertEquals(excepted.status,actual.status)
             assertEquals(excepted.message,actual.message)
         }


### PR DESCRIPTION
… in tests; Implemented unit tests for Application, Controller, and Service; Failed exception handling issue in controller template test, triggered at endpoint return.

Exception output reads as: "Request processing failed; nested exception is com.thomasdriscoll.template.lib.exceptions.DriscollException: You done goofed"